### PR TITLE
Form prefixes

### DIFF
--- a/dc_signup_form/constants.py
+++ b/dc_signup_form/constants.py
@@ -1,0 +1,2 @@
+MAILING_LIST_FORM_PREFIX = "mailing_list_form"
+ELECTION_REMINDERS_FORM_PREFIX = "election_reminders_form"

--- a/dc_signup_form/context_processors.py
+++ b/dc_signup_form/context_processors.py
@@ -1,4 +1,8 @@
 from .forms import ElectionRemindersSignupForm, MailingListSignupForm
+from .constants import (
+    MAILING_LIST_FORM_PREFIX,
+    ELECTION_REMINDERS_FORM_PREFIX
+)
 
 
 def signup_form(request):
@@ -6,17 +10,27 @@ def signup_form(request):
         'source_url': request.path
     }
 
-    if request.POST:
-        return {
-            'mailing_list_form': MailingListSignupForm(
-                initial=initial, data=request.POST),
-            'election_reminders_form': ElectionRemindersSignupForm(
-                initial=initial, data=request.POST),
-        }
+    if MAILING_LIST_FORM_PREFIX in request.POST:
+        mailing_list_form = MailingListSignupForm(
+            initial=initial,
+            data=request.POST,
+        )
     else:
-        return {
-            'mailing_list_form': MailingListSignupForm(
-                initial=initial),
-            'election_reminders_form': ElectionRemindersSignupForm(
-                initial=initial),
-        }
+        mailing_list_form = MailingListSignupForm(
+            initial=initial
+        )
+
+    if ELECTION_REMINDERS_FORM_PREFIX in request.POST:
+        election_reminders_form = ElectionRemindersSignupForm(
+            initial=initial,
+            data=request.POST,
+        )
+    else:
+        election_reminders_form = ElectionRemindersSignupForm(
+            initial=initial
+        )
+
+    return {
+        'mailing_list_form': mailing_list_form,
+        'election_reminders_form': election_reminders_form,
+    }

--- a/dc_signup_form/forms.py
+++ b/dc_signup_form/forms.py
@@ -1,5 +1,7 @@
 from django import forms
 
+from .constants import ELECTION_REMINDERS_FORM_PREFIX, MAILING_LIST_FORM_PREFIX
+
 
 class EmailSignupForm(forms.Form):
     full_name = forms.CharField(required=True, max_length=1000,
@@ -10,6 +12,9 @@ class EmailSignupForm(forms.Form):
 
 
 class ElectionRemindersSignupForm(EmailSignupForm):
+
+    prefix = ELECTION_REMINDERS_FORM_PREFIX
+
     main_list = forms.BooleanField(
         required=False,
         initial=False,
@@ -20,6 +25,9 @@ class ElectionRemindersSignupForm(EmailSignupForm):
 
 
 class MailingListSignupForm(EmailSignupForm):
+
+    prefix = MAILING_LIST_FORM_PREFIX
+
     main_list = forms.BooleanField(
         initial=True,
         widget=forms.HiddenInput())

--- a/dc_signup_form/templates/email_form/election_reminders_form.html
+++ b/dc_signup_form/templates/email_form/election_reminders_form.html
@@ -11,6 +11,6 @@
       <div class="form-group">
         {{ election_reminders_form|dc_form }}
       </div>
-      <button type="submit" class="button">Sign up</button>
+      <button type="submit" class="button" name="{{ election_reminders_form.prefix }}">Sign up</button>
     </form>
 {% endif %}

--- a/dc_signup_form/templates/email_form/mailing_list_form.html
+++ b/dc_signup_form/templates/email_form/mailing_list_form.html
@@ -6,6 +6,6 @@
     <div class="form-group">
       {{ mailing_list_form|dc_form }}
     </div>
-    <button type="submit" class="button">Join us</button>
+    <button type="submit" class="button" name="{{ mailing_list_form.prefix }}">Join us</button>
   </form>
 {% endif %}

--- a/dc_signup_form/tests/test_forms.py
+++ b/dc_signup_form/tests/test_forms.py
@@ -1,28 +1,42 @@
 from django.test import TestCase
 from dc_signup_form.forms import (
     ElectionRemindersSignupForm, MailingListSignupForm)
+from dc_signup_form.constants import (
+    MAILING_LIST_FORM_PREFIX,
+    ELECTION_REMINDERS_FORM_PREFIX
+)
+
+def add_data_prefix(prefix, data):
+    return {
+        "{}-{}".format(prefix, k): v
+        for k, v in data.items()
+        if not str(v).startswith(k)
+    }
+
 
 
 class TestForms(TestCase):
-
     def test_mailing_list_form_valid(self):
-        form = MailingListSignupForm(data={
+        data = add_data_prefix(MAILING_LIST_FORM_PREFIX, {
             'full_name': 'Chad Fernandez',
             'email': 'chad.fernandez@democracyclub.org.uk',
             'source_url': 'http://foo.bar/baz',
             'main_list': True,
         })
+
+        form = MailingListSignupForm(data)
         if not form.is_valid():
             print(form.errors)
         self.assertTrue(form.is_valid())
 
     def test_mailing_list_invalid(self):
-        form = MailingListSignupForm(data={
+        data = add_data_prefix(MAILING_LIST_FORM_PREFIX, {
             'full_name': '',  # empty field
             'email': 'foo',  # not an email
             'source_url': 'http://foo.bar/baz',
             'main_list': True,
         })
+        form = MailingListSignupForm(data)
         self.assertFalse(form.is_valid())
         self.assertIn('full_name', form.errors)
         self.assertIn('This field is required.', form.errors['full_name'])
@@ -42,24 +56,26 @@ class TestForms(TestCase):
         self.assertIn('This field is required.', form.errors['main_list'])
 
     def test_election_reminders_form_valid(self):
-        form = ElectionRemindersSignupForm(data={
+        data = add_data_prefix(ELECTION_REMINDERS_FORM_PREFIX, {
             'full_name': 'Chad Fernandez',
             'email': 'chad.fernandez@democracyclub.org.uk',
             'source_url': 'http://foo.bar/baz',
             'main_list': False,
             'election_reminders': True,
         })
+        form = ElectionRemindersSignupForm(data)
         if not form.is_valid():
             print(form.errors)
         self.assertTrue(form.is_valid())
 
     def test_election_reminders_invalid(self):
-        form = ElectionRemindersSignupForm(data={
+        data = add_data_prefix(ELECTION_REMINDERS_FORM_PREFIX, {
             'full_name': '',  # empty field
             'email': 'foo',  # not an email
             'source_url': 'http://foo.bar/baz',
             'main_list': True,
         })
+        form = ElectionRemindersSignupForm(data)
         self.assertFalse(form.is_valid())
         self.assertIn('full_name', form.errors)
         self.assertIn('This field is required.', form.errors['full_name'])

--- a/dc_signup_form/tests/test_views.py
+++ b/dc_signup_form/tests/test_views.py
@@ -1,6 +1,15 @@
 from django.test import Client, TestCase
 from dc_signup_form.signup_server.models import SignupQueue
 
+from dc_signup_form.constants import (
+    MAILING_LIST_FORM_PREFIX,
+    ELECTION_REMINDERS_FORM_PREFIX
+)
+
+from .test_forms import add_data_prefix
+
+
+
 
 class TestView(TestCase):
 
@@ -9,10 +18,10 @@ class TestView(TestCase):
         response = c.get('/emails/mailing_list/')
         self.assertEqual(200, response.status_code)
         expected_strings = [
-            '<input id="id_source_url" name="source_url" type="hidden" value="/emails/mailing_list/" />',
-            '<input id="id_main_list" name="main_list" type="hidden" value="True" />',
-            '<input class=" form-control" id="id_full_name" maxlength="1000" name="full_name" type="text" required />',
-            '<input class=" form-control" id="id_email" maxlength="255" name="email" type="email" required />',
+            '<input id="id_mailing_list_form-source_url" name="mailing_list_form-source_url" type="hidden" value="/emails/mailing_list/" />',
+            '<input id="id_mailing_list_form-main_list" name="mailing_list_form-main_list" type="hidden" value="True" />',
+            '<input class=" form-control" id="id_mailing_list_form-full_name" maxlength="1000" name="mailing_list_form-full_name" type="text" required />',
+            '<input class=" form-control" id="id_mailing_list_form-email" maxlength="255" name="mailing_list_form-email" type="email" required />',
         ]
         for string in expected_strings:
             self.assertContains(response, string, html=True)
@@ -20,24 +29,35 @@ class TestView(TestCase):
     def test_post_mailing_list_form_view_valid(self):
         self.assertEqual(0, len(SignupQueue.objects.all()))
         c = Client()
-        response = c.post('/emails/mailing_list/', {
-            'source_url': '/emails/mailing_list/',
-            'main_list': True,
-            'full_name': 'Chad Fernandez',
-            'email': 'chad.fernandez@example.com',
-        })
+        response = c.post(
+            '/emails/mailing_list/',
+            add_data_prefix(MAILING_LIST_FORM_PREFIX, {
+                'source_url': '/emails/mailing_list/',
+                'main_list': True,
+                'full_name': 'Chad Fernandez',
+                'email': 'chad.fernandez@example.com',
+                'mailing_list_form': '',
+            })
+        )
         self.assertEqual(302, response.status_code)
         self.assertEqual(1, len(SignupQueue.objects.all()))
 
     def test_post_mailing_list_form_view_invalid(self):
         self.assertEqual(0, len(SignupQueue.objects.all()))
         c = Client()
-        response = c.post('/emails/mailing_list/', {
-            'source_url': '/emails/mailing_list/',
-            'main_list': True,
-            'full_name': 'Chad Fernandez',
-            'email': '',
-        })
+
+        response = c.post(
+            '/emails/mailing_list/',
+            add_data_prefix(MAILING_LIST_FORM_PREFIX, {
+                'source_url': '/emails/mailing_list/',
+                'main_list': True,
+                'full_name': 'Chad Fernandez',
+                'email': '',
+                'mailing_list_form': '',
+            })
+        )
+        form = response.context[MAILING_LIST_FORM_PREFIX]
+        self.assertFalse(form.is_valid())
         self.assertEqual(200, response.status_code)
         self.assertIn('<div class="form-group has-error">', str(response.content))
         self.assertEqual(0, len(SignupQueue.objects.all()))
@@ -47,11 +67,11 @@ class TestView(TestCase):
         response = c.get('/emails/election_reminders/')
         self.assertEqual(200, response.status_code)
         expected_strings = [
-            '<input id="id_source_url" name="source_url" type="hidden" value="/emails/election_reminders/" />',
-            '<input id="id_election_reminders" name="election_reminders" type="hidden" value="True" />',
-            '<input class=" form-control" id="id_full_name" maxlength="1000" name="full_name" type="text" required />',
-            '<input class=" form-control" id="id_email" maxlength="255" name="email" type="email" required />',
-            '<input id="id_main_list" name="main_list" type="checkbox" />',
+            '<input id="id_election_reminders_form-source_url" name="election_reminders_form-source_url" type="hidden" value="/emails/election_reminders/" />',
+            '<input id="id_election_reminders_form-election_reminders" name="election_reminders_form-election_reminders" type="hidden" value="True" />',
+            '<input class=" form-control" id="id_election_reminders_form-full_name" maxlength="1000" name="election_reminders_form-full_name" type="text" required />',
+            '<input class=" form-control" id="id_election_reminders_form-email" maxlength="255" name="election_reminders_form-email" type="email" required />',
+            '<input id="id_election_reminders_form-main_list" name="election_reminders_form-main_list" type="checkbox" />',
         ]
         for string in expected_strings:
             self.assertContains(response, string, html=True)
@@ -59,13 +79,17 @@ class TestView(TestCase):
     def test_post_election_reminders_form_view_valid(self):
         self.assertEqual(0, len(SignupQueue.objects.all()))
         c = Client()
-        response = c.post('/emails/election_reminders/', {
-            'source_url': '/emails/election_reminders/',
-            'election_reminders': True,
-            'full_name': 'Chad Fernandez',
-            'email': 'chad.fernandez@example.com',
-            'main_list': False,
-        })
+        response = c.post(
+            '/emails/election_reminders/',
+            add_data_prefix(ELECTION_REMINDERS_FORM_PREFIX, {
+                'source_url': '/emails/election_reminders/',
+                'election_reminders': True,
+                'full_name': 'Chad Fernandez',
+                'email': 'chad.fernandez@example.com',
+                'main_list': False,
+                'election_reminders_form': '',
+            })
+        )
         self.assertEqual(302, response.status_code)
         self.assertEqual(1, len(SignupQueue.objects.all()))
 
@@ -78,6 +102,7 @@ class TestView(TestCase):
             'full_name': 'Chad Fernandez',
             'email': '',
             'main_list': False,
+            'election_reminders_form': '',
         })
         self.assertEqual(200, response.status_code)
         self.assertIn('<div class="form-group has-error">', str(response.content))

--- a/dc_signup_form/urls.py
+++ b/dc_signup_form/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
         r'^mailing_list/$',
         SignupFormView.as_view(
             template_name='email_form/mailing_list_form_view.html',
-            form_class=MailingListSignupForm
+            form_class=MailingListSignupForm,
         ),
         name='mailing_list_signup_view'),
     url(

--- a/dc_signup_form/views.py
+++ b/dc_signup_form/views.py
@@ -48,13 +48,26 @@ class SignupFormView(FormView):
         else:
             return "/"
 
-    def form_valid(self, form):
+    def form_invalid(self, form):
+        """
+        Add the form to the context using the form prefix as the var name.
 
+        This is because we use the prefix in the template to render this form,
+        without this we would render the 'clean' form from the context
+        processor, hiding any errors thrown.
+        """
+        context_form_name = form.prefix
+        return self.render_to_response(
+            self.get_context_data(**{context_form_name: form})
+        )
+
+    def form_valid(self, form):
         mailing_lists = []
         data = form.cleaned_data.copy()
 
         # mailing lists
         for lst in self.mailing_lists:
+            key = "-".join([self.form_class.prefix, lst])
             if data.pop(lst, False):
                 mailing_lists.append(lst)
 

--- a/setup.py
+++ b/setup.py
@@ -14,5 +14,6 @@ setup(
     url='https://github.com/DemocracyClub/dc_signup_form',
     install_requires=[
         'requests',
+        "Django >=1.10,<2.1"
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='dc_signup_form',
-    version='2.0.0',
+    version='2.0.1',
     author="chris48s",
     packages=find_packages(),
     include_package_data=True,

--- a/testing_requirements.txt
+++ b/testing_requirements.txt
@@ -2,4 +2,4 @@ coverage
 psycopg2
 python-coveralls
 
-git+git://github.com/DemocracyClub/dc_base_theme.git@39c3588e7f29e83c9f77dbba0083cd0811321811
+git+git://github.com/DemocracyClub/dc_base_theme.git@0.3.7


### PR DESCRIPTION
This adds form prefixes to both forms, meaning that when they appear on
a page with other forms then validation doesn't get performed on the
wrong form.

For example, if a form error shows on a page for another form, the
mailing list form gets "This field is required" as an error, something
that's confusing if the user isn't trying to fill that form out.