### PR TITLE
Hotfix/signup-message

### DIFF
--- a/dc_signup_form/views.py
+++ b/dc_signup_form/views.py
@@ -15,7 +15,7 @@ class SignupFormView(FormView):
     ]  # list of the mailing lists we support joining
     get_vars = []  # list of get vars we want to store with the user
     extras = {}  # dict of hard-coded key/value pairs we want to store with the user
-    thanks_message = "Thanks for joining. We'll be in touch soon!"
+    thanks_message = "Thanks for joining the Democracy Club mailing list. We will be in touch soon!"
 
     backends = {
         'test': TestBackend(),


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/dc_signup_form/issues/10

This work makes mailing list confirmation message more specific: 

`thanks_message = "Thanks for joining the Democracy Club mailing list. We will be in touch soon!"`