### PR TITLE
Refactor safe_source_url

### DIFF
--- a/dc_signup_form/views.py
+++ b/dc_signup_form/views.py
@@ -56,10 +56,8 @@ class SignupFormView(FormView):
         except NoReverseMatch:
             election_reminders_signup_view = ""
 
-        try:
-            source_url_safe = get_http(source_url, host=self.request.get_host())
-        except TypeError:
-            source_url_safe = get_http(source_url)
+        source_url_safe = get_http(source_url, host=self.request.get_host())
+        
         if (
             source_url_safe
             and source_url != mailing_list_signup_view


### PR DESCRIPTION
This change addresses an error with calling get_http() without a host arguement. This error has only been raised in WCIVF, but does not occur in Website. 

```
[TypeError](https://democracy-club-gp.sentry.io/issues/3759797450/) /mailing_list/signup/
get_http() missing 1 required positional argument: 'host'

```

 [Before - 5/23/2023, 8:32:34 AM](https://vimeo.com/829321913/3c1ea0a5d2)

 [After - 5/23/2023, 8:30:29 AM](https://vimeo.com/829321453/87962a7bf1)