### PR TITLE
Accept Django >=3.2,<4.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Django >=3.2,<4.3
+psycopg2-binary


### PR DESCRIPTION
This change expands accepted Django versions to include `4.2` . Tested within WCIVF. 
