### PR TITLE
Match required installs to requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     url="https://github.com/DemocracyClub/dc_signup_form",
     install_requires=[
         'requests',
-        'Django >=2.0,<4.2',
+        'Django >=3.2,<4.3',
         'psycopg2-binary',
     ],
     setup_requires=["wheel"],


### PR DESCRIPTION
This is a follow up to https://github.com/DemocracyClub/dc_signup_form/pull/27 to match the Django versionining in `setup.cfg` to requirements file. 