### PR TITLE
Add validation to name field

### DIFF
--- a/dc_signup_form/forms.py
+++ b/dc_signup_form/forms.py
@@ -1,13 +1,23 @@
 from django import forms
+from django.core.validators import RegexValidator
 
 from .constants import ELECTION_REMINDERS_FORM_PREFIX, MAILING_LIST_FORM_PREFIX
 
 
+def emails_not_accepted(value):
+    if '@' in value:
+        raise forms.ValidationError("Please enter your full name, not your email address.")
+
 class EmailSignupForm(forms.Form):
-    full_name = forms.CharField(required=True, max_length=1000, label="Name")
+    full_name = forms.CharField(
+        required=True, 
+        max_length=1000, 
+        label="Full Name",
+        validators=[emails_not_accepted],
+        widget=forms.TextInput(attrs={'autocomplete': 'off', 'pattern': '[^@]+', 'title': 'Please enter your full name, not your email address.'})
+    )
     email = forms.EmailField(required=True, max_length=255, label="Email")
     source_url = forms.CharField(widget=forms.HiddenInput())
-
 
 class ElectionRemindersSignupForm(EmailSignupForm):
 

--- a/dc_signup_form/tests/test_forms.py
+++ b/dc_signup_form/tests/test_forms.py
@@ -47,6 +47,20 @@ class TestForms(TestCase):
         self.assertIn("This field is required.", form.errors["full_name"])
         self.assertIn("email", form.errors)
         self.assertIn("Enter a valid email address.", form.errors["email"])
+    
+    def test_mailing_list_invalid_name(self):
+        data = add_data_prefix(
+            MAILING_LIST_FORM_PREFIX,
+            {
+                "full_name": "andrew@foo.com",  # @ in name
+                "email": "andrew@foo.com",  # not an email
+                "source_url": "http://foo.bar/baz",
+                "main_list": True,
+            },
+        )
+        form = MailingListSignupForm(data)
+        self.assertFalse(form.is_valid())
+        self.assertIn("Please enter your name, not your email address.", form.errors["full_name"])
 
     def test_mailing_list_required_fields(self):
         form = MailingListSignupForm(data={})


### PR DESCRIPTION
Ref https://app.asana.com/0/1204880927741389/1205190227431755/f

This work adds front and back end validation and prevents email addresses from being saved in the name field and sent to sendgrid.

To test, `pip install` locally into Website or WCIVF and submit an email address into the name field. The error should appear. For contrast, try to submit the form without any information to see the built in form validation. 

![Screenshot 2023-09-12 at 2 59 16 PM](https://github.com/DemocracyClub/dc_signup_form/assets/7017118/8e2f1926-22c0-43be-bed9-a0d8af8ce994)


```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Tests have been added and/or updated
- [x] Screenshot of the feature/bug fix (if applicable)
- [x] Did I explain all possible solutions and why I chose the one I did?
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205190227431755