### PR TITLE
Eventbridge backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Django app with Email signup form for use on Democracy Club websites. Currently,
 Add to project requirements:
 
 ```
-git+git://github.com/DemocracyClub/dc_base_theme.git
 git+git://github.com/DemocracyClub/dc_signup_form.git
 ```
+
+This project depends on [`dc_django_utils`](https://github.com/DemocracyClub/dc_django_utils) 
+and we assume this is already set up on the project
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -22,50 +22,42 @@ and we assume this is already set up on the project
 
 ## Configuration
 
-Using the remote backend (default):
+For all backends, `dc_signup_form` needs to be in `INSTALLED_APPS` and
+`dc_signup_form.context_processors.signup_form` needs to be added as a 
+context processor.
+
+
+Using AWS EventBridge (recommended):
 
 ```python
-INSTALLED_APPS = [
-    ...
-    'dc_signup_form',
-]
 
-TEMPLATES = [
-    {
-        ...
-        'OPTIONS': {
-            'context_processors': [
-                ...
-                'dc_signup_form.context_processors.signup_form',
-            ],
-        },
-    }
-]
+EMAIL_SIGNUP_BACKEND = "event_bridge"
+EMAIL_SIGNUP_BACKEND_KWARGS = {
+    "source": "NAME OF THIS SOURCE, e.g the project name",
+    "bus_arn": "[ARN of the event bridge bus. Take this from the dev handbook]"
+}
+
+```
+
+Note that `bus_arn` needs to change for dev, stage and prod accounts. It's 
+recomended to take this from the environment when running the app.
+
+Using the remote backend (deprecated):
+
+```python
 
 EMAIL_SIGNUP_API_KEY = 'f00b42'
 EMAIL_SIGNUP_ENDPOINT = 'https://foo.bar/baz/'
 ```
 
-Using the local backend:
+Using the local backend (deprecated):
 
 ```python
 INSTALLED_APPS = [
     ...
-    'dc_signup_form',
     'dc_signup_form.signup_server',
 ]
 
-TEMPLATES = [
-    {
-        ...
-        'OPTIONS': {
-            'context_processors': [
-                ...
-                'dc_signup_form.context_processors.signup_form',
-            ],
-        },
-    }
-]
 
 SENDGRID_API_KEY = 'f00b42'
 ```
@@ -136,4 +128,3 @@ or display the form inline:
 ## Tests
 
 run ```python run_tests.py```
-

--- a/dc_signup_form/backends.py
+++ b/dc_signup_form/backends.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 import requests
 import json
 from django.conf import settings
@@ -36,3 +37,93 @@ class RemoteDbBackend:
 
         r = requests.post(url, data=json.dumps(payload), headers=headers)
         r.raise_for_status()
+
+
+@dataclass
+class EmailSubscriber:
+    name: str
+    email: str
+    list_uuids: list
+    source: str = None
+    extra_context: dict = None
+    status: str = "enabled"
+
+    def __post_init__(self):
+        # Validate email
+        if "@" not in self.email:
+            raise ValueError("Invalid email address.")
+        if "@" in self.name:
+            raise ValueError("Name cannot contain an email address")
+        if not isinstance(self.list_uuids, list):
+            raise ValueError("'list_uuids' must be a list")
+        self.list_uuids = list([int(x) for x in self.list_uuids])
+
+    def as_listmonk_json(self):
+        return {
+            "email": self.email,
+            "name": self.name,
+            "status": self.status,
+            "lists": self.list_uuids,
+            "attribs": self.extra_context,
+        }
+
+
+class EventBridgeBackend:
+    def __init__(self, source=None, bus_arn=None):
+        if not source:
+            raise ValueError("'source' required. This should be the project name")
+
+        self.source = source
+
+        if not bus_arn:
+            raise ValueError("'bus_arn' for this environment required")
+        self.bus_arn = bus_arn
+
+        self.dev_mode = False
+        if bus_arn.endswith("development"):
+            self.dev_mode = True
+
+        # Import locally because it's an optional extra only used in this class
+        import boto3
+
+        self.client = boto3.client("events", region_name="eu-west-2")
+
+    def list_name_to_list_id(self, dev_mode):
+        """
+        ListMonk uses numeric list IDs to add subscribers.
+
+        These IDs are just the PK of the list in the database, so depend on the install.
+
+        There is no way to give them a slug or other unique ID that can be relied on.
+
+        Because of this, we hard code these IDs here. It's not ideal, but at least
+        keeps the logic ina single place.
+
+        Because these IDs (might) change between ListMonk installs, we need two dicts,
+        one for dev and one for prod.
+        """
+
+        if dev_mode:
+            return {"main_list": "3"}
+
+        # Prod values
+        return {"main_list": "4"}
+
+    def submit(self, data, mailing_lists):
+        list_id_map = self.list_name_to_list_id(self.dev_mode)
+        list_ids = list([list_id_map[list_name] for list_name in mailing_lists])
+
+        subscriber = EmailSubscriber(
+            email=data["email"], name=data["full_name"], list_uuids=list_ids
+        )
+
+        self.client.put_events(
+            Entries=[
+                {
+                    "Source": self.source,
+                    "DetailType": "new_subscription",
+                    "Detail": json.dumps(subscriber.as_listmonk_json()),
+                    "EventBusName": self.bus_arn,
+                },
+            ],
+        )

--- a/dc_signup_form/tests/test_forms.py
+++ b/dc_signup_form/tests/test_forms.py
@@ -60,7 +60,7 @@ class TestForms(TestCase):
         )
         form = MailingListSignupForm(data)
         self.assertFalse(form.is_valid())
-        self.assertIn("Please enter your name, not your email address.", form.errors["full_name"])
+        self.assertIn("Please enter your full name, not your email address.", form.errors["full_name"])
 
     def test_mailing_list_required_fields(self):
         form = MailingListSignupForm(data={})

--- a/dc_signup_form/tests/test_views.py
+++ b/dc_signup_form/tests/test_views.py
@@ -17,11 +17,12 @@ class TestView(TestCase):
         expected_strings = [
             '<input id="id_mailing_list_form-source_url" name="mailing_list_form-source_url" type="hidden" value="/emails/mailing_list/" />',
             '<input id="id_mailing_list_form-main_list" name="mailing_list_form-main_list" type="hidden" value="True" />',
-            '<input class=" form-control" id="id_mailing_list_form-full_name" maxlength="1000" name="mailing_list_form-full_name" type="text" required />',
-            '<input class=" form-control" id="id_mailing_list_form-email" maxlength="255" name="mailing_list_form-email" type="email" required />',
+            '<input type="text" name="mailing_list_form-full_name" autocomplete="off" pattern="[^@]+" title="Please enter your full name, not your email address." maxlength="1000" class="" required="" id="id_mailing_list_form-full_name">',
+            '<input type="email" name="mailing_list_form-email" maxlength="255" class="" required="" id="id_mailing_list_form-email">',
         ]
         for string in expected_strings:
-            self.assertContains(response, string, html=True)
+            with self.subTest(string=string):
+                self.assertContains(response, string, html=True)
 
     def test_post_mailing_list_form_view_valid(self):
         self.assertEqual(0, len(SignupQueue.objects.all()))
@@ -88,7 +89,7 @@ class TestView(TestCase):
         form = response.context[MAILING_LIST_FORM_PREFIX]
         self.assertFalse(form.is_valid())
         self.assertEqual(200, response.status_code)
-        self.assertIn('<div class="form-group has-error">', str(response.content))
+        self.assertIn('<div class="ds-error">', str(response.content))
         self.assertEqual(0, len(SignupQueue.objects.all()))
 
     def test_get_election_reminders_form_view(self):
@@ -98,12 +99,13 @@ class TestView(TestCase):
         expected_strings = [
             '<input id="id_election_reminders_form-source_url" name="election_reminders_form-source_url" type="hidden" value="/emails/election_reminders/" />',
             '<input id="id_election_reminders_form-election_reminders" name="election_reminders_form-election_reminders" type="hidden" value="True" />',
-            '<input class=" form-control" id="id_election_reminders_form-full_name" maxlength="1000" name="election_reminders_form-full_name" type="text" required />',
-            '<input class=" form-control" id="id_election_reminders_form-email" maxlength="255" name="election_reminders_form-email" type="email" required />',
+            '<input type="text" name="election_reminders_form-full_name" autocomplete="off" pattern="[^@]+" title="Please enter your full name, not your email address." maxlength="1000" class="" required id="id_election_reminders_form-full_name">',
+            '<input type="email" name="election_reminders_form-email" maxlength="255" class="" required id="id_election_reminders_form-email">',
             '<input id="id_election_reminders_form-main_list" name="election_reminders_form-main_list" type="checkbox" />',
         ]
         for string in expected_strings:
-            self.assertContains(response, string, html=True)
+            with self.subTest(string=string):
+                self.assertContains(response, string, html=True)
 
     def test_post_election_reminders_form_view_valid(self):
         self.assertEqual(0, len(SignupQueue.objects.all()))
@@ -140,5 +142,5 @@ class TestView(TestCase):
             },
         )
         self.assertEqual(200, response.status_code)
-        self.assertIn('<div class="form-group has-error">', str(response.content))
+        self.assertIn('<div class="ds-error">', str(response.content))
         self.assertEqual(0, len(SignupQueue.objects.all()))

--- a/dc_signup_form/views.py
+++ b/dc_signup_form/views.py
@@ -5,6 +5,7 @@ from .backends import (
     LocalDbBackend,
     RemoteDbBackend,
     TestBackend,
+    EventBridgeBackend,
 )
 
 
@@ -31,11 +32,13 @@ class SignupFormView(FormView):
     )
 
     backends = {
-        "test": TestBackend(),
-        "local_db": LocalDbBackend(),
-        "remote_db": RemoteDbBackend(),
+        "test": TestBackend,
+        "local_db": LocalDbBackend,
+        "remote_db": RemoteDbBackend,
+        "event_bridge": EventBridgeBackend,
     }
     backend = "remote_db"
+    backend_kwargs = {}
 
     def get_success_url(self):
         messages.success(self.request, self.thanks_message)
@@ -100,6 +103,6 @@ class SignupFormView(FormView):
 
         # pass the payload off to a backend object
         # to deal with persisting the data to a db
-        self.backends[self.backend].submit(data, mailing_lists)
+        self.backends[self.backend](**self.backend_kwargs).submit(data, mailing_lists)
 
         return super(SignupFormView, self).form_valid(form)

--- a/run_tests.py
+++ b/run_tests.py
@@ -25,7 +25,7 @@ if not settings.configured:
         INSTALLED_APPS=(
             "django.contrib.contenttypes",
             "django.contrib.staticfiles",
-            "dc_theme",
+            "dc_utils",
             "test_project",
             "dc_signup_form",
             "dc_signup_form.signup_server",
@@ -41,7 +41,7 @@ if not settings.configured:
                 "OPTIONS": {
                     "debug": True,
                     "context_processors": [
-                        "dc_theme.context_processors.dc_theme_context",
+                        "dc_utils.context_processors.dc_django_utils",
                         "dc_signup_form.context_processors.signup_form",
                     ],
                 },
@@ -51,6 +51,7 @@ if not settings.configured:
             "django.contrib.sessions.middleware.SessionMiddleware",
             "django.contrib.messages.middleware.MessageMiddleware",
         ],
+        SECRET_KEY="testing_key"
     )
 
 django.setup()

--- a/setup.py
+++ b/setup.py
@@ -26,4 +26,8 @@ setup(
         'psycopg2-binary',
     ],
     setup_requires=["wheel"],
+    # We don't want to force boto3 for all installs
+    # For example AWS Lambda already has it by default.
+    # Mark as optional
+    extras_require={'boto': ['boto3']}
 )

--- a/testing_requirements.txt
+++ b/testing_requirements.txt
@@ -1,3 +1,3 @@
 coveralls>=1.10.0
-
-git+git://github.com/DemocracyClub/dc_base_theme.git@0.3.18
+https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.4.0.tar.gz
+django-localflavor==4.0

--- a/testing_requirements.txt
+++ b/testing_requirements.txt
@@ -1,3 +1,5 @@
 coveralls>=1.10.0
 https://github.com/DemocracyClub/dc_django_utils/archive/refs/tags/2.4.0.tar.gz
 django-localflavor==4.0
+boto3
+moto==4.2.2


### PR DESCRIPTION
https://app.asana.com/0/1204880927741389/1205128315644772

Two things in the PR:

1. Fix the test and replace the old base theme. This commit replaces #13 
2. Adds a new backend for EventBridge. This will, one day, remove the need for the DC website to host a server, but I'm keeping the server code around until we've changed to the new backend on all projects that use this library. 

The tests should cover this, but it would be useful to implement this on a project locally and test. If doing this, you'll need to have a valid AWS_PROFILE exported when you run that project (use a dev one!)


```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Tests have been added and/or updated
- [x] Have I rebased with the latest version of master?
- [x] Added PR labels
- [x] Update any documentation
- [x] Update dev handbook
```
